### PR TITLE
Allow for multiple clients

### DIFF
--- a/lib/shutterstock-ruby.rb
+++ b/lib/shutterstock-ruby.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'rest_client'
+require 'shutterstock-ruby/configuration'
 require 'shutterstock-ruby/connections'
 require 'shutterstock-ruby/images'
 require 'shutterstock-ruby/videos'
@@ -9,24 +10,22 @@ module ShutterstockRuby
   API_BASE = 'api.shutterstock.com/v2'
 
   def self.configuration
-    @configuration ||=  Configuration.new
+    @configuration ||=  Configuration.new({})
   end
 
   def self.configure
-    self.configuration ||= Configuration.new
+    self.configuration ||= Configuration.new({})
     yield(configuration) if block_given?
   end
 
-  # Main configuration class.
-  class Configuration
-    attr_accessor :access_token
-    attr_accessor :api_client
-    attr_accessor :api_secret
+  class Client
+    attr_reader :configuration, :videos, :images
 
-    def initialize
-      @access_token = nil
-      @api_client = nil
-      @api_secret = nil
+    def initialize(args = {})
+      @configuration = Configuration.new(args)
+      @videos = Videos.new(configuration)
+      @images = Images.new(configuration)
     end
+
   end
 end

--- a/lib/shutterstock-ruby/configuration.rb
+++ b/lib/shutterstock-ruby/configuration.rb
@@ -1,0 +1,13 @@
+module ShutterstockRuby
+  class Configuration
+    attr_accessor :access_token
+    attr_accessor :api_client
+    attr_accessor :api_secret
+
+    def initialize(args)
+      @access_token = args[:access_token]
+      @api_client = args[:api_client]
+      @api_secret = args[:api_secret]
+    end
+  end
+end

--- a/lib/shutterstock-ruby/connections.rb
+++ b/lib/shutterstock-ruby/connections.rb
@@ -1,5 +1,11 @@
 module ShutterstockRuby
-  module Connections
+  class Connections
+    attr_reader :configuration
+
+    def initialize(configuration)
+      @configuration = configuration
+    end
+
     def get(path, params = nil, options = {})
       ensure_credentials!
 
@@ -18,24 +24,28 @@ module ShutterstockRuby
       RestClient.post(build_url(path), body, add_bearer(options))
     end
 
+    protected
+    def self.client
+      @client ||= new(ShutterstockRuby.configuration)
+    end
+
     private
 
     def build_url(path)
-      if ShutterstockRuby.configuration.access_token
+      if configuration.access_token
         "https://#{ShutterstockRuby::API_BASE}#{path}"
       else
-        "https://#{ShutterstockRuby.configuration.api_client}:#{ShutterstockRuby.configuration.api_secret}@#{ShutterstockRuby::API_BASE}#{path}"
+        "https://#{configuration.api_client}:#{configuration.api_secret}@#{ShutterstockRuby::API_BASE}#{path}"
       end
     end
 
     def add_bearer(options)
-      options[:authorization] = "Bearer #{ShutterstockRuby.configuration.access_token}" if ShutterstockRuby.configuration.access_token
+      options[:authorization] = "Bearer #{configuration.access_token}" if configuration.access_token
       options
     end
 
     def ensure_credentials!
-      config = ShutterstockRuby.configuration
-      fail(Exception, 'Missing credentials') if (config.api_client.nil? || config.api_secret.nil?) && config.access_token.nil?
+      fail(Exception, 'Missing credentials') if (configuration.api_client.nil? || configuration.api_secret.nil?) && configuration.access_token.nil?
     end
   end
 end

--- a/lib/shutterstock-ruby/images.rb
+++ b/lib/shutterstock-ruby/images.rb
@@ -1,10 +1,15 @@
 module ShutterstockRuby
   # A class to hold all images related code.
-  class Images
-    extend Connections
+  class Images < Connections
 
-    def self.search(query, options = {})
-      JSON.parse(self.get('/images/search', { query: query }.merge(options)))
+    def search(query, options = {})
+      JSON.parse(get('/images/search', { query: query }.merge(options)))
+    end
+
+    class << self
+      def search(query, options = {})
+        client.search(query, options)
+      end
     end
   end
 end

--- a/lib/shutterstock-ruby/videos.rb
+++ b/lib/shutterstock-ruby/videos.rb
@@ -1,20 +1,33 @@
 module ShutterstockRuby
   # A class to hold all videos related code.
-  class Videos
-    extend Connections
+  class Videos < Connections
 
-    def self.search(query, options = {})
-      JSON.parse(self.get('/videos/search', { query: query }.merge(options)))
+    def search(query, options = {})
+      JSON.parse(get('/videos/search', { query: query }.merge(options)))
     end
 
-    def self.details(id, options = {})
-      JSON.parse(self.get('/videos', { id: id }.merge(options)))
+    def details(id, options = {})
+      JSON.parse(get('/videos', { id: id }.merge(options)))
     end
 
-    def self.purchase(id, subscription_id, size, options = {})
+    def purchase(id, subscription_id, size, options = {})
       params = { subscription_id: subscription_id, size: size }
       body = { videos: [ video_id: id ] }.to_json
-      JSON.parse(self.post("/videos/licenses", body, params, options))
+      JSON.parse(post("/videos/licenses", body, params, options))
+    end
+
+    class << self
+      def search(query, options = {})
+        client.search(query, options)
+      end
+
+      def details(id, options = {})
+        client.details(id, options)
+      end
+
+      def purchase(id, subscription_id, size, options = {})
+        client.purchase(id, subscription_id, size, options)
+      end
     end
   end
 end

--- a/shutterstock-ruby.gemspec
+++ b/shutterstock-ruby.gemspec
@@ -4,7 +4,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'shutterstock-ruby'
-  s.version     = '0.3.0'
+  s.version     = '0.4.0'
   s.platform    = Gem::Platform::RUBY
   s.date        = Date.today.to_s
   s.summary     = "An API wrapper for the Shutterstock API's"

--- a/spec/lib/shutterstock_ruby_spec.rb
+++ b/spec/lib/shutterstock_ruby_spec.rb
@@ -1,6 +1,30 @@
 require 'spec_helper'
 
-RSpec.describe ShutterstockRuby do
+RSpec.describe "ShutterstockRuby instance client" do
+
+  it 'has the correct default' do
+    client = ShutterstockRuby::Client.new
+
+    expect(client.configuration.access_token).to be nil
+    expect(client.configuration.api_client).to be nil
+    expect(client.configuration.api_secret).to be nil
+  end
+
+  it 'sets the correct configuration' do
+    token = SecureRandom.uuid
+    key = SecureRandom.uuid
+    secret = SecureRandom.uuid
+
+    client = ShutterstockRuby::Client.new(access_token: token, api_client: key, api_secret: secret)
+
+    expect(client.configuration.access_token).to equal(token)
+    expect(client.configuration.api_client).to equal(key)
+    expect(client.configuration.api_secret).to equal(secret)
+  end
+end
+
+
+RSpec.describe "ShutterstockRuby static client" do
   after :each do
     ShutterstockRuby.configuration.access_token = nil
     ShutterstockRuby.configuration.api_client = nil


### PR DESCRIPTION
We require multiple clients with different access tokens, so this PR allows for that while keeping backwards compatibility with the existing static calls.

```ruby
def client
  @client ||= ShutterstockRuby::Client.new(access_token: access_token)
end

def search(q)
  client.videos.search(q)
end
```