### PR TITLE
Allow purchase metadata and download existing purchase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
                             --format RspecJunitFormatter \
                             --out /tmp/test-results/rspec.xml \
                             --format progress \
-                            "${TEST_FILES}"
+                            ${TEST_FILES}
 
       # collect reports
       - store_test_results:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ ShutterstockRuby.configure do |config|
 end
 ```
 
+If you require multiple clients, you can create an instance:
+```rb
+@client ||= ShutterstockRuby::Client.new(access_token: access_token)
+```
+
+You must supply either an `api_client` and an `api_secret`, or an `access_token`.
+
 ### Search for images
 
 ```rb
@@ -39,10 +46,46 @@ Source [source](https://developers.shutterstock.com/api/v2/images/search)
 
 ### Search for videos
 
+Using the singleton client:
 ```rb
 result = ShutterstockRuby::Videos.search('Cat') # Returns a hash of the parsed JSON result.
 ```
+
+Using an instance of the client:
+```rb
+result = @client.videos.search('Cat') # Returns a hash of the parsed JSON result.
+```
+
 Source [source](https://developers.shutterstock.com/api/v2/videos/search)
+
+### Details for a video
+
+```rb
+result = @client.videos.details(video_id) # Returns a hash of the parsed JSON result.
+```
+Source [source](https://developers.shutterstock.com/api/v2/videos/get)
+
+### Purchase a video
+
+```rb
+result = @client.videos.purchase(video_id, subscription_id, size) # Returns a hash of the parsed JSON result.
+```
+Source [source](https://developers.shutterstock.com/api/v2/videos/license)
+
+### Retrieve an existing license for a video
+
+```rb
+result = @client.videos.licenses(video_id, license_name) # Returns a hash of the parsed JSON result.
+```
+Source [source](https://developers.shutterstock.com/api/v2/videos/licenses)
+
+### Download a video that has already been purchased
+
+```rb
+result = @client.videos.download(license_id) # Returns a hash of the parsed JSON result.
+```
+Source [source](https://developers.shutterstock.com/api/v2/videos/download)
+
 
 ## Disclaimer
 

--- a/lib/shutterstock-ruby/videos.rb
+++ b/lib/shutterstock-ruby/videos.rb
@@ -23,6 +23,10 @@ module ShutterstockRuby
       JSON.parse(get("/videos/licenses", params.merge(options)))
     end
 
+    def download(licence)
+      JSON.parse(post("/videos/licenses/#{licence}/downloads", {}.to_json))
+    end
+
     class << self
       def search(query, options = {})
         client.search(query, options)

--- a/lib/shutterstock-ruby/videos.rb
+++ b/lib/shutterstock-ruby/videos.rb
@@ -12,8 +12,15 @@ module ShutterstockRuby
 
     def purchase(id, subscription_id, size, options = {})
       params = { subscription_id: subscription_id, size: size }
-      body = { videos: [ video_id: id ] }.to_json
+      metadata = options.delete(:metadata) || {}
+
+      body = { videos: [ { video_id: id }.merge(metadata)] }.to_json
       JSON.parse(post("/videos/licenses", body, params, options))
+    end
+
+    def licenses(video_id, license, options = {})
+      params = { video_id: video_id, license: license }
+      JSON.parse(get("/videos/licenses", params.merge(options)))
     end
 
     class << self

--- a/shutterstock-ruby.gemspec
+++ b/shutterstock-ruby.gemspec
@@ -4,7 +4,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'shutterstock-ruby'
-  s.version     = '0.4.0'
+  s.version     = '0.4.1'
   s.platform    = Gem::Platform::RUBY
   s.date        = Date.today.to_s
   s.summary     = "An API wrapper for the Shutterstock API's"

--- a/spec/lib/shutterstock_ruby/videos_spec.rb
+++ b/spec/lib/shutterstock_ruby/videos_spec.rb
@@ -1,0 +1,153 @@
+require 'spec_helper'
+
+RSpec.describe "ShutterstockRuby Videos API" do
+
+  before do
+    @client = ShutterstockRuby::Client.new.videos
+  end
+
+  it 'can search for videos' do
+    allow(@client).to receive(:get).with("/videos/search", { query: "cats" }).and_return(search_json)
+    expect(@client.search("cats")).to eq(JSON.parse(search_json))
+  end
+
+  it 'can search for videos with options' do
+    allow(@client).to receive(:get).with("/videos/search", { query: "cats", per_page: 10 }).and_return(search_json)
+    expect(@client.search("cats", { per_page: 10 })).to eq(JSON.parse(search_json))
+  end
+
+  it 'can get the details for a video' do
+    allow(@client).to receive(:get).with("/videos", { id: "1234" }).and_return(video_json)
+    expect(@client.details("1234")).to eq(JSON.parse(video_json))
+  end
+
+  it 'can purchase a video' do
+    allow(@client).to receive(:post).with(
+      "/videos/licenses",
+      { videos: [ { video_id: "1234" } ]}.to_json,
+      { subscription_id: "s5678", size: "hd"},
+      {}
+    ).and_return(purchase_json)
+
+    expect(@client.purchase("1234", "s5678", "hd")).to eq(JSON.parse(purchase_json))
+  end
+
+  it 'can purchase a video with metadata and options' do
+    allow(@client).to receive(:post).with(
+        "/videos/licenses",
+        { videos: [ { video_id: "1234", price: 20 } ] }.to_json,
+        { subscription_id: "s5678", size: "hd"},
+        { my_header: "header" }
+    ).and_return(purchase_json)
+
+    expect(@client.purchase("1234", "s5678", "hd", { metadata: { price: 20 }, my_header: "header" })).to eq(JSON.parse(purchase_json))
+  end
+
+  it 'can get an existing license for a video' do
+    allow(@client).to receive(:get).with("/videos/licenses", { video_id: "1234", license: "comp" }).and_return(license_json)
+    expect(@client.licenses("1234", "comp")).to eq(JSON.parse(license_json))
+  end
+
+  it 'can get an download link for an existing license' do
+    allow(@client).to receive(:post).with("/videos/licenses/v5678/downloads", {}.to_json).and_return(download_json)
+    expect(@client.download("v5678")).to eq(JSON.parse(download_json))
+  end
+
+  private
+  def search_json
+    %Q({
+        "page": 1,
+        "per_page": 1,
+        "total_count": 1,
+        "search_id": "abcd",
+        "data": [
+            #{video_json}
+        ]
+    })
+  end
+
+  def purchase_json
+    %q({
+        "data": [
+          {
+            "video_id": "1234",
+            "download": {
+              "url": "http://localhost/1234.mov"
+            },
+            "allotment_charge": 1
+          }
+        ]
+      })
+  end
+
+  def download_json
+    %q({
+        "url": "http://localhost/1234.mov"
+      })
+  end
+
+  def video_json
+    %q({
+        "media_type": "video",
+        "id": "1234",
+        "description": "",
+        "aspect": 1.778,
+        "duration": 26,
+        "contributor": {
+          "id": "1234"
+        },
+        "aspect_ratio": "16:9",
+        "assets": {
+          "thumb_webm": {
+            "url": "http://localhost/1234/cats.webm"
+          },
+          "thumb_mp4": {
+            "url": "http://localhost/1234/cats.mp4"
+          },
+          "preview_webm": {
+            "url": "http://localhost/1234/cats.webm"
+          },
+          "preview_mp4": {
+            "url": "http://localhost/1234/cats.mp4"
+          },
+          "thumb_jpg": {
+            "url": "http://localhost/1234/cats7.jpg"
+          },
+          "preview_jpg": {
+            "url": "http://localhost/1234/cats7.jpg"
+          }
+        }
+      })
+  end
+
+  def license_json
+    %q({
+        "data": [
+          {
+            "id": "v5678",
+            "user": {
+              "username": "user"
+            },
+            "license": "comp",
+            "subscription_id": "s1234",
+            "download_time": "2017-10-09T20:31:04-04:00",
+            "metadata": {
+              "client": "",
+              "other": "",
+              "job": "",
+              "purchase_order": ""
+            },
+            "is_downloadable": true,
+            "video": {
+              "id": "1234",
+              "format": {
+                "size": "hd"
+              }
+            }
+          }
+        ],
+        "page": 1,
+        "per_page": 1
+      })
+  end
+end


### PR DESCRIPTION
- Allows you to check if a video has already been purchased and to get the download url for it
- Allows you to send through metadata when purchasing a video